### PR TITLE
fix: expose mmCIF Validate in command palette

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -35,6 +35,13 @@
     "onLanguage:cif"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "mmcif.validate",
+        "title": "mmCIF: Validate",
+        "category": "mmCIF"
+      }
+    ],
     "languages": [
       {
         "id": "cif",


### PR DESCRIPTION
This should fix #17 by exposing a `contributes.commands` entry for `mmcif.validate` in `vscode-extension/package.json`.