### PR TITLE
Show error if validation script fails

### DIFF
--- a/vscode-extension/src/validation.ts
+++ b/vscode-extension/src/validation.ts
@@ -313,17 +313,23 @@ export async function validateDocument(
             clearDepositionStatusBar(ctx.depositionStatusBarItem);
             ctx.onDepositionUpdate?.(document.uri.toString(), null);
         }
-    } else if (exitCode === 1 && stderr) {
-        const match = stderr.match(/Error: (.+)/);
-        if (match) {
-            diagnostics = [
-                new vscode.Diagnostic(
-                    new vscode.Range(0, 0, 0, Number.MAX_VALUE),
-                    match[1],
-                    vscode.DiagnosticSeverity.Error
-                ),
-            ];
+    } else if (exitCode !== undefined && exitCode > 0) {
+        let message = `Validation script failed (exit code ${exitCode}).`;
+        if (stderr) {
+            const match = stderr.match(/Error: (.+)/);
+            if (match && match[1]) {
+                message = match[1];
+            } else if (stderr.trim()) {
+                message = stderr.trim();
+            }
         }
+        diagnostics = [
+            new vscode.Diagnostic(
+                new vscode.Range(0, 0, 0, Number.MAX_VALUE),
+                message,
+                vscode.DiagnosticSeverity.Error
+            ),
+        ];
         clearDepositionStatusBar(ctx.depositionStatusBarItem);
         ctx.onDepositionUpdate?.(document.uri.toString(), null);
     } else {


### PR DESCRIPTION
This addresses the last part of #16.

If the validation script fails with any non-0 exit code (for instance 127 if the `python` command was not found) it will produce a clear diagnostic message such as:

    /bin/sh: python: command not found [Ln1, Col1]

I had to refactor the error matching as well. Stderr may not contain the exact `Error: ` match. New behavior will be to extract the error after  `Error: ` as currently, if present; otherwise, print the full stderr; and if no stderr is message is available, print `Validation script failed (exit code ${exitCode})` as a fallback.