### PR TITLE
Fix metadata completeness import

### DIFF
--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -43,4 +43,4 @@ Repository = "https://github.com/PDBeurope/mmcif-validator"
 validate-mmcif = "validate_mmcif:main"
 
 [tool.setuptools]
-py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness"]
+py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness", "completeness"]

--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -43,4 +43,5 @@ Repository = "https://github.com/PDBeurope/mmcif-validator"
 validate-mmcif = "validate_mmcif:main"
 
 [tool.setuptools]
-py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness", "completeness"]
+py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness"]
+packages = ["completeness"]

--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -43,4 +43,4 @@ Repository = "https://github.com/PDBeurope/mmcif-validator"
 validate-mmcif = "validate_mmcif:main"
 
 [tool.setuptools]
-py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator"]
+py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness"]


### PR DESCRIPTION
Added module `metadata_completeness` and package `completeness` to `pyproject.toml` to solve getting import errors when using as a library.

[I've checked that the script usage, as documented in the readme, is unaffected, but not the VS Code extension mode.]