### PR TITLE
version to 0.1.83: add loop folding UX improvements

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -1,5 +1,5 @@
 # Build the VS Code extension and publish the .vsix to GitHub Releases when a version tag is pushed.
-# Usage: create a tag (e.g. v0.1.82), push it, then find the .vsix on the Releases page.
+# Usage: create a tag (e.g. v0.1.83), push it, then find the .vsix on the Releases page.
 
 name: Release VS Code extension
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # PDBe mmCIF Validator
 
-**Version 0.1.82**
+**Version 0.1.83**
 
 Real-time VSCode extension and standalone Python script for validating mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary.
 
-Release **0.1.82** fixes PyPI/wheel packaging so `metadata_completeness` and the `completeness` package ship with the install, declares **mmCIF: Validate** in the extension manifest for the Command Palette, and improves VS Code diagnostics when the validation subprocess exits with a non-zero code (clearer stderr / exit-code messaging).
-
-**0.1.81** added a regression testing suite and improved the core validator and dictionary parser: loop/frame handling, `asym_id` checks, dictionary enumerations and loop-style item definitions, and deterministic ordering of errors and metadata-completeness output.
+Release **0.1.83** adds loop folding for CIF `loop_` blocks and inline loop category labels (for easier navigation when folded), while keeping the previous packaging and validation subprocess robustness improvements.
 
 ## Overview
 
@@ -87,7 +85,7 @@ For detailed information about all validation checks, error severity levels, and
 
 Pre-built VS Code extension packages (`.vsix`) are published on the [GitHub Releases](https://github.com/PDBeurope/mmcif-validator/releases) page. To install a specific version, download the `.vsix` from the desired release and install it via **Extensions → ⋯ → Install from VSIX...**.
 
-Releases are created from git tags (e.g. `v0.1.82`). Pushing a version tag triggers a GitHub Action that builds the extension and attaches the `.vsix` to the corresponding release.
+Releases are created from git tags (e.g. `v0.1.83`). Pushing a version tag triggers a GitHub Action that builds the extension and attaches the `.vsix` to the corresponding release.
 
 ## Contributing
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the PDBe mmCIF Validator extension will be documented in 
 
 # Released
 
+## [0.1.83] - 2026-04-08
+
+### Added
+
+- **VS Code — loop folding**: Added a CIF folding provider so `loop_` blocks can be collapsed/expanded reliably in large files (ends at next structural keyword or EOF).
+- **VS Code — loop context labels**: Added inline loop labels that show the loop category name after `loop_` (derived from the first loop tag, e.g. `loop_ atom_site`) to make folded sections easier to identify.
+- **VS Code — loop symbols for navigation**: Added a CIF document-symbol provider that emits loop symbols (e.g. `loop_ _atom_site.group_PDB`) for improved Outline/Sticky Scroll context.
+
 ## [0.1.82] - 2026-03-25
 
 ### Added

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # PDBe mmCIF Validator
 
-**Version 0.1.82**
+**Version 0.1.83**
 
 A Visual Studio Code extension to validate mmCIF/CIF files against the PDBx/mmCIF dictionary (or any CIF dictionary) with real-time error checking.
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdbe-mmcif-validator",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdbe-mmcif-validator",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "pdbe-mmcif-validator",
   "displayName": "PDBe mmCIF Validator",
   "description": "Validates mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary with real-time error checking",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "author": "Deborah Harrus <Protein Data Bank in Europe (PDBe), EMBL-EBI>",
   "publisher": "PDBEurope",
   "icon": "icon.png",

--- a/vscode-extension/python-script/README.md
+++ b/vscode-extension/python-script/README.md
@@ -1,10 +1,10 @@
 # PDBe mmCIF Validator - Python Script
 
-**Version 0.1.82**
+**Version 0.1.83**
 
 A standalone Python script to validate mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary.
 
-**0.1.82** — Packaging: `pyproject.toml` now includes `metadata_completeness` and the `completeness` package in the built distribution so metadata completeness and its data files install correctly from PyPI.
+**0.1.83** — Version alignment release for the extension/package set (no standalone Python CLI behavior changes).
 
 **0.1.81** improved real-world dictionary and file handling: loops followed by key–value pairs of the same category, stricter `asym_id` checks, loop-style item definitions and `_pdbx_item_enumeration`, and deterministic ordering for regression comparisons.
 

--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdbe-mmcif-validator"
-version = "0.1.82"
+version = "0.1.83"
 description = "Validate mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary"
 readme = "README.md"
 license = { text = "MIT" }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,9 @@ import { createHoverProvider } from './hover';
 import { validateDocument, updateMetadataCompletenessUIFromCache } from './validation';
 import { MetadataCompleteness } from './types';
 import { updateDepositionReadiness, registerDepositionView } from './depositionView';
+import { CifFoldingRangeProvider } from './folding';
+import { CifDocumentSymbolProvider } from './symbols';
+import { createLoopLabelDecoration, updateLoopLabels } from './loopLabels';
 
 export function activate(context: vscode.ExtensionContext): void {
     const outputChannel = vscode.window.createOutputChannel('PDBe mmCIF Validator');
@@ -59,6 +62,8 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 
     const metadataByUri = new Map<string, MetadataCompleteness | null>();
+    const loopLabelDecoration = createLoopLabelDecoration();
+    context.subscriptions.push(loopLabelDecoration);
 
     const validationCtx = {
         outputChannel,
@@ -89,11 +94,16 @@ export function activate(context: vscode.ExtensionContext): void {
             updateMetadataCompletenessUIFromCache(null, validationCtx);
             updateDepositionReadiness(null);
         }
+        updateLoopLabels(editor, loopLabelDecoration);
     });
 
     vscode.workspace.onDidOpenTextDocument((document) => {
         if (document.languageId === 'cif' || document.fileName.endsWith('.cif')) {
             validateDocument(document, diagnosticCollection, validationCtx);
+        }
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor && activeEditor.document.uri.toString() === document.uri.toString()) {
+            updateLoopLabels(activeEditor, loopLabelDecoration);
         }
     });
 
@@ -101,11 +111,19 @@ export function activate(context: vscode.ExtensionContext): void {
         if (document.languageId === 'cif' || document.fileName.endsWith('.cif')) {
             validateDocument(document, diagnosticCollection, validationCtx);
         }
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor && activeEditor.document.uri.toString() === document.uri.toString()) {
+            updateLoopLabels(activeEditor, loopLabelDecoration);
+        }
     });
 
     let timeout: NodeJS.Timeout | undefined;
     vscode.workspace.onDidChangeTextDocument((event) => {
         if (event.document.languageId === 'cif' || event.document.fileName.endsWith('.cif')) {
+            const activeEditor = vscode.window.activeTextEditor;
+            if (activeEditor && activeEditor.document.uri.toString() === event.document.uri.toString()) {
+                updateLoopLabels(activeEditor, loopLabelDecoration);
+            }
             if (timeout) clearTimeout(timeout);
             timeout = setTimeout(() => {
                 validateDocument(event.document, diagnosticCollection, validationCtx);
@@ -126,11 +144,19 @@ export function activate(context: vscode.ExtensionContext): void {
     const hoverProvider = vscode.languages.registerHoverProvider('cif', createHoverProvider(outputChannel));
     context.subscriptions.push(hoverProvider);
 
+    const foldingProvider = vscode.languages.registerFoldingRangeProvider('cif', new CifFoldingRangeProvider());
+    context.subscriptions.push(foldingProvider);
+
+    const symbolProvider = vscode.languages.registerDocumentSymbolProvider('cif', new CifDocumentSymbolProvider());
+    context.subscriptions.push(symbolProvider);
+
     vscode.workspace.textDocuments.forEach((document) => {
         if (document.languageId === 'cif' || document.fileName.endsWith('.cif')) {
             validateDocument(document, diagnosticCollection, validationCtx);
         }
     });
+
+    updateLoopLabels(vscode.window.activeTextEditor, loopLabelDecoration);
 }
 
 export function deactivate(): void {}

--- a/vscode-extension/src/folding.ts
+++ b/vscode-extension/src/folding.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+const STRUCTURAL_KEYWORD_RE = /^(?:DATA_|LOOP_|SAVE_|GLOBAL_|STOP_)\b/i;
+
+/**
+ * Folding ranges for CIF loop_ blocks.
+ * A loop starts at a line containing LOOP_ and ends before the next structural keyword or EOF.
+ */
+export class CifFoldingRangeProvider implements vscode.FoldingRangeProvider {
+    provideFoldingRanges(
+        document: vscode.TextDocument,
+        _context: vscode.FoldingContext,
+        _token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.FoldingRange[]> {
+        const ranges: vscode.FoldingRange[] = [];
+        const lineCount = document.lineCount;
+
+        for (let i = 0; i < lineCount; i++) {
+            const lineText = document.lineAt(i).text.trim();
+            if (!/^LOOP_\b/i.test(lineText)) {
+                continue;
+            }
+
+            let end = lineCount - 1;
+            for (let j = i + 1; j < lineCount; j++) {
+                const nextText = document.lineAt(j).text.trim();
+                if (STRUCTURAL_KEYWORD_RE.test(nextText)) {
+                    end = j - 1;
+                    break;
+                }
+            }
+
+            while (end > i && document.lineAt(end).text.trim() === '') {
+                end--;
+            }
+
+            if (end > i) {
+                ranges.push(new vscode.FoldingRange(i, end, vscode.FoldingRangeKind.Region));
+            }
+        }
+
+        return ranges;
+    }
+}
+

--- a/vscode-extension/src/loopLabels.ts
+++ b/vscode-extension/src/loopLabels.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+
+const STRUCTURAL_KEYWORD_RE = /^(?:DATA_|LOOP_|SAVE_|GLOBAL_|STOP_)\b/i;
+
+function extractCategoryFromTag(tag: string): string | null {
+    const trimmed = tag.trim();
+    if (!trimmed.startsWith('_')) {
+        return null;
+    }
+    const withoutUnderscore = trimmed.slice(1);
+    const dotIdx = withoutUnderscore.indexOf('.');
+    return dotIdx > 0 ? withoutUnderscore.slice(0, dotIdx) : withoutUnderscore || null;
+}
+
+function firstLoopCategory(document: vscode.TextDocument, loopStartLine: number): string | null {
+    for (let i = loopStartLine + 1; i < document.lineCount; i++) {
+        const text = document.lineAt(i).text.trim();
+        if (!text || text.startsWith('#')) {
+            continue;
+        }
+        if (STRUCTURAL_KEYWORD_RE.test(text)) {
+            return null;
+        }
+        if (text.startsWith('_')) {
+            const tag = text.split(/\s+/)[0];
+            return extractCategoryFromTag(tag);
+        }
+        // Reached data rows before a tag.
+        return null;
+    }
+    return null;
+}
+
+export function createLoopLabelDecoration(): vscode.TextEditorDecorationType {
+    return vscode.window.createTextEditorDecorationType({
+        after: {
+            color: new vscode.ThemeColor('descriptionForeground'),
+            margin: '0 0 0 0.6em',
+        },
+        rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+    });
+}
+
+export function updateLoopLabels(
+    editor: vscode.TextEditor | undefined,
+    decoration: vscode.TextEditorDecorationType
+): void {
+    if (!editor) {
+        return;
+    }
+    const doc = editor.document;
+    if (doc.languageId !== 'cif' && !doc.fileName.endsWith('.cif')) {
+        editor.setDecorations(decoration, []);
+        return;
+    }
+
+    const items: vscode.DecorationOptions[] = [];
+    for (let i = 0; i < doc.lineCount; i++) {
+        const text = doc.lineAt(i).text.trim();
+        if (!/^LOOP_\b/i.test(text)) {
+            continue;
+        }
+        const category = firstLoopCategory(doc, i);
+        if (!category) {
+            continue;
+        }
+
+        const loopRaw = doc.lineAt(i).text;
+        const loopMatch = loopRaw.match(/loop_/i);
+        const startChar = loopMatch ? loopMatch.index ?? 0 : 0;
+        const endChar = startChar + 5;
+        items.push({
+            range: new vscode.Range(i, startChar, i, endChar),
+            renderOptions: {
+                after: {
+                    contentText: `${category}`,
+                },
+            },
+        });
+    }
+
+    editor.setDecorations(decoration, items);
+}
+

--- a/vscode-extension/src/symbols.ts
+++ b/vscode-extension/src/symbols.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+
+const STRUCTURAL_KEYWORD_RE = /^(?:DATA_|LOOP_|SAVE_|GLOBAL_|STOP_)\b/i;
+
+function firstLoopTag(document: vscode.TextDocument, loopStartLine: number, loopEndLine: number): string | null {
+    for (let i = loopStartLine + 1; i <= loopEndLine; i++) {
+        const text = document.lineAt(i).text.trim();
+        if (!text || text.startsWith('#')) {
+            continue;
+        }
+        if (text.startsWith('_')) {
+            return text.split(/\s+/)[0];
+        }
+        if (STRUCTURAL_KEYWORD_RE.test(text)) {
+            break;
+        }
+        // First data row reached; tag section ended.
+        break;
+    }
+    return null;
+}
+
+/**
+ * Document symbols for CIF loops to improve outline and sticky-scroll context.
+ */
+export class CifDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(
+        document: vscode.TextDocument,
+        _token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+        const symbols: vscode.DocumentSymbol[] = [];
+        const lineCount = document.lineCount;
+
+        for (let i = 0; i < lineCount; i++) {
+            const lineText = document.lineAt(i).text.trim();
+            if (!/^LOOP_\b/i.test(lineText)) {
+                continue;
+            }
+
+            let end = lineCount - 1;
+            for (let j = i + 1; j < lineCount; j++) {
+                const nextText = document.lineAt(j).text.trim();
+                if (STRUCTURAL_KEYWORD_RE.test(nextText)) {
+                    end = j - 1;
+                    break;
+                }
+            }
+
+            while (end > i && document.lineAt(end).text.trim() === '') {
+                end--;
+            }
+            if (end <= i) {
+                continue;
+            }
+
+            const tag = firstLoopTag(document, i, end);
+            const name = tag ? `loop_ ${tag}` : 'loop_';
+            const fullRange = new vscode.Range(i, 0, end, document.lineAt(end).text.length);
+            const selectionRange = new vscode.Range(i, 0, i, document.lineAt(i).text.length);
+            symbols.push(new vscode.DocumentSymbol(name, '', vscode.SymbolKind.Namespace, fullRange, selectionRange));
+        }
+
+        return symbols;
+    }
+}
+


### PR DESCRIPTION
Bump project/version metadata from 0.1.82 to 0.1.83 across extension, Python package, and docs.

Add VS Code/Cursor loop navigation UX enhancements: fold/collapse support for CIF loop_ blocks, loop symbols for outline/sticky context, and inline loop category labels; document all changes in the 0.1.83 changelog.