### PR TITLE
Updated pyproject.toml to include rules

### DIFF
--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -44,4 +44,4 @@ validate-mmcif = "validate_mmcif:main"
 
 [tool.setuptools]
 py-modules = ["validate_mmcif", "protocol", "mmcif_types", "download", "dict_parser", "cif_parser", "validator", "metadata_completeness"]
-packages = ["completeness"]
+packages = ["completeness", "rules"]


### PR DESCRIPTION
Added rules to the package to fix rules not being shipped with the whl.

Ideally longer term better solution is to fix the directory structure to have all code in a single folder, and project.toml outside of that folder. This will make the imports cleaner as well and avoid potential clashes.

Something like this:
```
├── pyproject.toml
└── pdbe_mmcif_validator/
    ├── __init__.py
    ├── validate_mmcif.py
    ├── validator.py
    ├── rules/
    ├── completeness/
    └── ...