### PR TITLE
security fix: use execFile instead of exec to prevent shell command i…

### DIFF
--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -98,16 +98,17 @@ export function getDictionarySource(workspaceFolder: vscode.WorkspaceFolder | un
 
 export function getScriptPath(extensionPath: string | undefined): string | null {
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
-    const possiblePaths = [
-        path.join(__dirname, '..', 'python-script', 'validate_mmcif.py'),
-        path.join(extensionPath || '', 'python-script', 'validate_mmcif.py'),
-        path.join(workspacePath, 'python-script', 'validate_mmcif.py'),
-        path.join(workspacePath, 'validate_mmcif.py'),
-    ];
+    const possiblePaths = [path.join(__dirname, '..', 'python-script', 'validate_mmcif.py')];
     if (extensionPath) {
         possiblePaths.push(
             path.join(extensionPath, 'python-script', 'validate_mmcif.py'),
             path.join(extensionPath, 'validate_mmcif.py')
+        );
+    }
+    if (workspacePath) {
+        possiblePaths.push(
+            path.join(workspacePath, 'python-script', 'validate_mmcif.py'),
+            path.join(workspacePath, 'validate_mmcif.py')
         );
     }
     return possiblePaths.find(p => fs.existsSync(p)) ?? null;

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -96,20 +96,54 @@ export function getDictionarySource(workspaceFolder: vscode.WorkspaceFolder | un
     return dictSource ? { dictSource, useUrl } : null;
 }
 
+const SCRIPT_RELATIVE = path.join('python-script', 'validate_mmcif.py');
+
+function isPathInsideRoot(candidate: string, root: string): boolean {
+    const resolved = path.resolve(candidate);
+    const resolvedRoot = path.resolve(root);
+    const rel = path.relative(resolvedRoot, resolved);
+    return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function resolveTrustedScriptPath(candidate: string, trustedRoot: string): string | null {
+    if (candidate.includes('\0')) {
+        return null;
+    }
+    const resolved = path.resolve(candidate);
+    if (!isPathInsideRoot(resolved, trustedRoot)) {
+        return null;
+    }
+    try {
+        const stat = fs.statSync(resolved);
+        if (!stat.isFile()) {
+            return null;
+        }
+    } catch {
+        return null;
+    }
+    return resolved;
+}
+
+/** Resolve the bundled validation script from the extension install only. */
 export function getScriptPath(extensionPath: string | undefined): string | null {
-    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
-    const possiblePaths = [path.join(__dirname, '..', 'python-script', 'validate_mmcif.py')];
+    const candidates: Array<{ path: string; trustedRoot: string }> = [];
     if (extensionPath) {
-        possiblePaths.push(
-            path.join(extensionPath, 'python-script', 'validate_mmcif.py'),
-            path.join(extensionPath, 'validate_mmcif.py')
-        );
+        candidates.push({
+            path: path.join(extensionPath, SCRIPT_RELATIVE),
+            trustedRoot: extensionPath,
+        });
     }
-    if (workspacePath) {
-        possiblePaths.push(
-            path.join(workspacePath, 'python-script', 'validate_mmcif.py'),
-            path.join(workspacePath, 'validate_mmcif.py')
-        );
+    const bundledRoot = path.resolve(__dirname, '..');
+    candidates.push({
+        path: path.join(bundledRoot, SCRIPT_RELATIVE),
+        trustedRoot: bundledRoot,
+    });
+
+    for (const { path: candidate, trustedRoot } of candidates) {
+        const resolved = resolveTrustedScriptPath(candidate, trustedRoot);
+        if (resolved) {
+            return resolved;
+        }
     }
-    return possiblePaths.find(p => fs.existsSync(p)) ?? null;
+    return null;
 }

--- a/vscode-extension/src/dictionary.ts
+++ b/vscode-extension/src/dictionary.ts
@@ -4,10 +4,10 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const CACHE_DIR_NAME = 'mmcif-validator-cache';
 const CACHE_FILENAME = 'mmcif_pdbx.dic';
@@ -58,8 +58,8 @@ export async function downloadAndCacheDictionary(
 
     outputChannel.appendLine(`Downloading dictionary from ${url}... (via Python script)`);
     try {
-        const command = `"${pythonPath}" "${scriptPath}" download-dictionary --url "${url}"`;
-        const { stdout } = await execAsync(command, { timeout: 120000 });
+        const args = [scriptPath, 'download-dictionary', '--url', url];
+        const { stdout } = await execFileAsync(pythonPath, args, { timeout: 120000 });
         const lines = stdout.split('\n');
         for (const line of lines) {
             const trimmed = line.trim();

--- a/vscode-extension/src/validation.ts
+++ b/vscode-extension/src/validation.ts
@@ -225,7 +225,7 @@ export async function validateDocument(
     if (!scriptPath || !fs.existsSync(scriptPath)) {
         outputChannel.appendLine('ERROR: Validation script not found.');
         vscode.window.showErrorMessage(
-            'Validation script not found. Please ensure validate_mmcif.py is in the extension or workspace.'
+            'Validation script not found. Please ensure the extension is installed correctly.'
         );
         diagnosticCollection.delete(document.uri);
         clearDepositionStatusBar(ctx.depositionStatusBarItem);

--- a/vscode-extension/src/validation.ts
+++ b/vscode-extension/src/validation.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import {
     ValidationErrorItem,
@@ -20,7 +20,7 @@ import {
 import { getSettings, getDictionarySource, getScriptPath } from './config';
 import { getCachedDictionaryPath, downloadAndCacheDictionary } from './dictionary';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface ValidationContext {
     outputChannel: vscode.OutputChannel;
@@ -262,18 +262,20 @@ export async function validateDocument(
     }
 
     const pythonPath = settings.pythonPath;
-    const command = useUrl
-        ? `"${pythonPath}" "${scriptPath}" --url "${dictSource}" "${document.fileName}"`
-        : `"${pythonPath}" "${scriptPath}" --file "${dictSource}" "${document.fileName}"`;
+    const args = useUrl
+        ? [scriptPath, '--url', dictSource, document.fileName]
+        : [scriptPath, '--file', dictSource, document.fileName];
 
-    outputChannel.appendLine(`Running: ${command}`);
+    outputChannel.appendLine(
+        `Running: ${pythonPath} ${args.map(a => JSON.stringify(a)).join(' ')}`
+    );
 
     let stdout = '';
     let stderr = '';
     let exitCode: number | undefined;
 
     try {
-        const result = await execAsync(command, { timeout: settings.validationTimeoutMs });
+        const result = await execFileAsync(pythonPath, args, { timeout: settings.validationTimeoutMs });
         stdout = result.stdout ?? '';
         stderr = result.stderr ?? '';
     } catch (err: unknown) {


### PR DESCRIPTION
…njection

Replace child_process.exec with execFile when running the Python validation script so paths and arguments are not interpreted by the shell. Addresses CodeQL js/shell-command-constructed-from-input alerts (#4–#6).
Also deduplicate extension/workspace script path candidates in getScriptPath().