### PR TITLE
version 0.1.94

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="img/logo-validator.png" alt="PDBe mmCIF Validator" width="200">
 
-**Version 0.1.93**
+**Version 0.1.94**
 
 Real-time VS Code extension, standalone Python tool, and online validator for mmCIF/CIF files.
 
@@ -133,6 +133,8 @@ See the [Python script README](vscode-extension/python-script/README.md) for det
 
 See the full [CHANGELOG](vscode-extension/CHANGELOG.md).
 
+Release **0.1.94** fixes hover tag assignment in loops that contain semicolon-delimited text fields, so continuation lines and closing `;` are not counted as extra values.
+
 Release **0.1.93** treats non-loop dictionary range endpoints as exclusive (matching DDL and OneDep) and flags `_pdbx_item.mandatory_code yes` items as missing when the category is present.
 
 Release **0.1.92** documents and automates the cross-check rules catalog workflow (`tools/generate_cross_check_rules_catalog.py`), including guidance to regenerate the catalog whenever `rules/data/cross_checks_*.json` changes.
@@ -143,7 +145,7 @@ Release **0.1.91** adds JSON-first procedural cross-checks, pairwise date-order 
 
 Pre-built VS Code extension packages (`.vsix`) are published on the [GitHub Releases](https://github.com/PDBeurope/mmcif-validator/releases) page. To install a specific version, download the `.vsix` from the desired release and install it via **Extensions → ⋯ → Install from VSIX...**.
 
-Releases are created from git tags (e.g. `v0.1.93`). Pushing a version tag triggers a GitHub Action that builds the extension and attaches the `.vsix` to the corresponding release.
+Releases are created from git tags (e.g. `v0.1.94`). Pushing a version tag triggers a GitHub Action that builds the extension and attaches the `.vsix` to the corresponding release.
 
 ## Contributing
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the PDBe mmCIF Validator extension will be documented in 
 
 # Released
 
+## [0.1.94] - 2026-08-18
+
+### Fixed
+
+- **Hover on semicolon-delimited loop values**: CIF hover now treats `;...;` text fields as a single loop value (STAR/CIF: `;` opens and closes only as the first character of a line). Continuation lines and the closing `;` are no longer counted as extra tokens, so later columns keep the correct tag. This fixes cases such as `_pdbx_seq_map_depositor_info`, where a following `entity_id` was shown as `one_letter_code`.
+
+### Changed
+
+- **Version bump**: Updated extension/package/docs version references from `0.1.93` to `0.1.94`.
+
 ## [0.1.93] - 2026-08-18
 
 ### Fixed

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/PDBeurope/mmcif-validator/main/img/logo-validator.png" alt="PDBe mmCIF Validator" width="200">
 
-**Version 0.1.93**
+**Version 0.1.94**
 
 A Visual Studio Code extension to validate mmCIF/CIF files against the PDBx/mmCIF dictionary (or any CIF dictionary) with real-time error checking.
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdbe-mmcif-validator",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdbe-mmcif-validator",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "pdbe-mmcif-validator",
   "displayName": "PDBe mmCIF Validator",
   "description": "Validates mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary with real-time error checking",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "author": "Deborah Harrus <Protein Data Bank in Europe (PDBe), EMBL-EBI>",
   "publisher": "PDBEurope",
   "icon": "icon.png",

--- a/vscode-extension/python-script/README.md
+++ b/vscode-extension/python-script/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/PDBeurope/mmcif-validator/main/img/logo-validator.png" alt="PDBe mmCIF Validator" width="200">
 
-**Version 0.1.93**
+**Version 0.1.94**
 
 A standalone Python script and PyPI package to validate mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary.
 

--- a/vscode-extension/python-script/pyproject.toml
+++ b/vscode-extension/python-script/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdbe-mmcif-validator"
-version = "0.1.93"
+version = "0.1.94"
 description = "Validate mmCIF/CIF files against the PDBx/mmCIF dictionary or any CIF dictionary"
 readme = "README.md"
 license = { text = "MIT" }

--- a/vscode-extension/src/cifParser.ts
+++ b/vscode-extension/src/cifParser.ts
@@ -115,38 +115,10 @@ export function getCifContext(document: vscode.TextDocument, position: vscode.Po
         
         // Now find the tag for the current position
         if (inLoop && loopTags.length > 0) {
-            // In a loop - count values to determine which tag
-            let valueCount = 0;
-            
-            // Count all values from loop start to current position
-            for (let i = loopStartLine + 1; i <= currentLine; i++) {
-                const line = lines[i];
-                
-                // Skip tag lines and comments
-                if (!line || line.trim().startsWith('_') || line.trim().startsWith('#') ||
-                    /^(DATA_|LOOP_|SAVE_|GLOBAL_|STOP_)/i.test(line.trim())) {
-                    continue;
-                }
-                
-                // Count values on this line
-                const values = extractValuesFromLine(line);
-                
-                // Check if current position is on this line
-                if (i === currentLine) {
-                    // Find which value on this line contains the cursor
-                    for (const value of values) {
-                        if (value.start <= currentChar && value.end >= currentChar) {
-                            // Found the value - determine tag
-                            const tagIndex = valueCount % loopTags.length;
-                            context.currentTag = loopTags[tagIndex];
-                            return context;
-                        }
-                        valueCount++;
-                    }
-                } else {
-                    // Not on current line, just count values
-                    valueCount += values.length;
-                }
+            const tag = findLoopTagAtPosition(lines, loopStartLine, loopTags, currentLine, currentChar);
+            if (tag) {
+                context.currentTag = tag;
+                return context;
             }
         } else {
             // Not in a loop - look for tag on current line or previous lines
@@ -207,6 +179,113 @@ interface ValueRange {
     end: number;
 }
 
+function isStructuralKeyword(line: string): boolean {
+    return /^(DATA_|LOOP_|SAVE_|GLOBAL_|STOP_)/i.test(line.trim());
+}
+
+function isLoopTagLine(line: string): boolean {
+    const trimmed = line.trim();
+    return trimmed.startsWith('_');
+}
+
+/**
+ * Semicolon-delimited CIF text fields start and end with ';' as the first
+ * character of a line (STAR/CIF spec). Continuation lines and the closing
+ * ';' are part of that one value, not additional loop tokens.
+ */
+function isSemicolonTextLine(line: string): boolean {
+    return line.length > 0 && line[0] === ';';
+}
+
+function tagAtCount(loopTags: string[], valueCount: number): string {
+    return loopTags[((valueCount % loopTags.length) + loopTags.length) % loopTags.length];
+}
+
+function valuesAfterClosingSemicolon(line: string): ValueRange[] {
+    // Tokens after the closing ';' on the same line are further loop values.
+    const rest = extractValuesFromLine(line.slice(1));
+    return rest.map((value) => ({ start: value.start + 1, end: value.end + 1 }));
+}
+
+/**
+ * Map a cursor position in a loop to the loop tag for that value.
+ * Counts semicolon-delimited text fields as a single value, matching gemmi.
+ */
+export function findLoopTagAtPosition(
+    lines: string[],
+    loopStartLine: number,
+    loopTags: string[],
+    currentLine: number,
+    currentChar: number
+): string | null {
+    if (loopTags.length === 0) {
+        return null;
+    }
+
+    let valueCount = 0;
+    let inSemicolonText = false;
+
+    for (let i = loopStartLine + 1; i <= currentLine; i++) {
+        const line = lines[i] ?? '';
+        const onCurrentLine = i === currentLine;
+
+        if (inSemicolonText) {
+            if (isSemicolonTextLine(line)) {
+                // Closing ';' ends the text field already counted at the opener.
+                inSemicolonText = false;
+                if (onCurrentLine) {
+                    if (currentChar <= 0) {
+                        return tagAtCount(loopTags, valueCount - 1);
+                    }
+                    const trailing = valuesAfterClosingSemicolon(line);
+                    for (const value of trailing) {
+                        if (value.start <= currentChar && value.end >= currentChar) {
+                            return tagAtCount(loopTags, valueCount);
+                        }
+                        valueCount++;
+                    }
+                    return null;
+                }
+                valueCount += valuesAfterClosingSemicolon(line).length;
+                continue;
+            }
+
+            // Continuation line of the current semicolon-delimited value.
+            if (onCurrentLine) {
+                return tagAtCount(loopTags, valueCount - 1);
+            }
+            continue;
+        }
+
+        if (!line.trim() || isLoopTagLine(line) || line.trim().startsWith('#') || isStructuralKeyword(line)) {
+            continue;
+        }
+
+        if (isSemicolonTextLine(line)) {
+            if (onCurrentLine) {
+                return tagAtCount(loopTags, valueCount);
+            }
+            valueCount++;
+            inSemicolonText = true;
+            continue;
+        }
+
+        const values = extractValuesFromLine(line);
+        if (onCurrentLine) {
+            for (const value of values) {
+                if (value.start <= currentChar && value.end >= currentChar) {
+                    return tagAtCount(loopTags, valueCount);
+                }
+                valueCount++;
+            }
+            return null;
+        }
+        valueCount += values.length;
+    }
+
+    return null;
+}
+
 function extractValuesFromLine(line: string): ValueRange[] {
     const values: ValueRange[] = [];
     let pos = 0;
@@ -245,12 +324,8 @@ function extractValuesFromLine(line: string): ValueRange[] {
                 end = spaceIndex > 0 ? spaceIndex : line.length;
             }
         }
-        // Multiline string (starts with ;)
-        else if (line[pos] === ';') {
-            // For simplicity, take to end of line (multiline strings span lines)
-            end = line.length;
-        }
-        // Unquoted value
+        // Unquoted value. A ';' here is an ordinary token; semicolon-delimited
+        // text fields are handled by findLoopTagAtPosition (must start at column 0).
         else {
             const spaceIndex = line.indexOf(' ', pos);
             const commentIndex = line.indexOf('#', pos);


### PR DESCRIPTION
Fix hover tagging for semicolon-delimited CIF loop values. Count ;...; text fields as a single loop value so later columns keep the correct tag.